### PR TITLE
feat: Enhance import/export and fix history

### DIFF
--- a/client/src/pages/history-tab.tsx
+++ b/client/src/pages/history-tab.tsx
@@ -5,11 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { Subject, QuestionAttempt } from "@shared/schema";
 
-interface HistoryTabProps {
-  onExport: () => void;
-}
-
-export function HistoryTab({ onExport }: HistoryTabProps) {
+export function HistoryTab() {
   const { data: attempts = [], isLoading } = useQuery<QuestionAttempt[]>({
     queryKey: ["question-attempts"],
     queryFn: () => api.questionAttempts.getByUser(),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -137,8 +137,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Export all question attempts
   app.get("/api/export", async (req, res) => {
     try {
-      const attempts = await storage.getAllQuestionAttempts();
-      res.json(attempts);
+      const data = await storage.exportAllData();
+      res.json(data);
     } catch (error) {
       res.status(500).json({ message: "Failed to export data" });
     }
@@ -147,15 +147,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Import question attempts
   app.post("/api/import", async (req, res) => {
     try {
-      const attempts = z.array(z.any()).parse(req.body);
-      await storage.importQuestionAttempts(attempts as any);
+      // Full data import
+      await storage.importAllData(req.body);
       res.json({ message: "Import successful" });
     } catch (error) {
-      if (error instanceof z.ZodError) {
-        res.status(400).json({ message: "Invalid data", errors: error.errors });
-      } else {
-        res.status(500).json({ message: "Failed to import data" });
-      }
+      console.error("Import error:", error);
+      res.status(500).json({ message: "Failed to import data" });
     }
   });
 


### PR DESCRIPTION
This commit introduces a comprehensive import/export functionality that allows you to back up and restore all your data, including question attempts, daily progress, and subjects.

Key changes:
- The export functionality now exports all data to a single JSON file.
- The import functionality now correctly imports all data from the exported JSON file.
- The import/export buttons are now located in the History tab.
- The frontend has been updated to provide better feedback during the import/export process.