### PR TITLE
feat: Add detailed subject analysis

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -112,6 +112,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Get topic-wise analytics for a subject
+  app.get("/api/analytics/subjects/:subjectId/topics", async (req, res) => {
+    try {
+      const userId = "demo-user-id";
+      const { subjectId } = req.params;
+      const topicStats = await storage.getTopicStats(userId, subjectId);
+      res.json(topicStats);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch topic analytics" });
+    }
+  });
+
+  // Get difficulty-wise analytics for a subject
+  app.get("/api/analytics/subjects/:subjectId/difficulty", async (req, res) => {
+    try {
+      const userId = "demo-user-id";
+      const { subjectId } = req.params;
+      const difficultyStats = await storage.getDifficultyStats(userId, subjectId);
+      res.json(difficultyStats);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch difficulty analytics" });
+    }
+  });
+
   // Get user stats
   app.get("/api/analytics/user", async (req, res) => {
     try {


### PR DESCRIPTION
This commit introduces a new "Detailed Subject Analysis" section to the dashboard. You can now select a subject to view more granular analytics, including:

-   **Topic Performance**: A bar chart showing accuracy for each topic within the selected subject.
-   **Performance by Difficulty**: A bar chart showing accuracy for each difficulty level (Easy, Medium, Hard) within the selected subject.

To support this, the following changes were made:

-   **Backend**: Added new API endpoints (`/api/analytics/subjects/:subjectId/topics` and `/api/analytics/subjects/:subjectId/difficulty`) and the corresponding data aggregation logic in the storage layer.
-   **Frontend**: Enhanced the "Analytics" tab in the dashboard with a subject selector and new charts to display the detailed performance data.